### PR TITLE
Fixed issue with looking for langCodes without a region that fail to find the base localization file

### DIFF
--- a/Pod/Classes/SILocalizationHelper.m
+++ b/Pod/Classes/SILocalizationHelper.m
@@ -141,10 +141,12 @@ static NSMutableDictionary *languageBundles;
     if ([SILocalizationHelper si_bundleLangCodeExists:langCode] || [SILocalizationHelper si_generateBundleForLangCode:langCode]) {
         return langCode;
     }
-    else {
+    // Check if the language has a region on the end of it.
+    // If it doesn't there is no need for this secondary check since the primary check already looked for the main langCode in the bundle.
+    else if ([langCode containsString:@"-"]) {
         NSRange rangeOfRegionStart = [langCode rangeOfString:@"-" options:NSBackwardsSearch];
         langCode = [langCode substringToIndex:rangeOfRegionStart.location];
-        
+    
         if ([SILocalizationHelper si_bundleLangCodeExists:langCode] || [SILocalizationHelper si_generateBundleForLangCode:langCode]) {
             return langCode;
         }


### PR DESCRIPTION
When there is a language (i.e. en) without a region in it and there is no translation file for the language. The application would crash due to the range of "-" being NSNotFound. Added in a check to see if there is a region before attempting to find that bundle in the app.
